### PR TITLE
Fix ROS cleaning

### DIFF
--- a/scripts/clean_ROS_debs.sh
+++ b/scripts/clean_ROS_debs.sh
@@ -8,7 +8,6 @@ remove-apt-package ros-$ROS_DISTRO-gencpp
 remove-apt-package ros-$ROS_DISTRO-geneus
 remove-apt-package ros-$ROS_DISTRO-genmsg
 remove-apt-package ros-$ROS_DISTRO-gennodejs
-remove-apt-package ros-$ROS_DISTRO-genpy
 remove-apt-package ros-$ROS_DISTRO-message-generation
 remove-apt-package ros-$ROS_DISTRO-roslint
 remove-apt-package ros-$ROS_DISTRO-roslisp


### PR DESCRIPTION
Do **not** clean packages `python3-catkin-pkg` & `ros-<DISTRO>-genpy` as both are use by `roslaunch` machinery. 