### PR TITLE
Do not remove genmsg

### DIFF
--- a/scripts/clean_ROS_debs.sh
+++ b/scripts/clean_ROS_debs.sh
@@ -6,7 +6,6 @@ set -x
 remove-apt-package ros-$ROS_DISTRO-cmake-modules
 remove-apt-package ros-$ROS_DISTRO-gencpp
 remove-apt-package ros-$ROS_DISTRO-geneus
-remove-apt-package ros-$ROS_DISTRO-genmsg
 remove-apt-package ros-$ROS_DISTRO-gennodejs
 remove-apt-package ros-$ROS_DISTRO-message-generation
 remove-apt-package ros-$ROS_DISTRO-roslint


### PR DESCRIPTION
`genmsg` modules are used by e.g. `rosservice` cli.