### PR TITLE
fix(ROS2): …

### DIFF
--- a/scripts/clean_ROS_2_debs.sh
+++ b/scripts/clean_ROS_2_debs.sh
@@ -3,10 +3,8 @@ set -x
 
 . "$(dirname "$0")/clean_debs.sh"
 
-remove-apt-package ros-$ROS_DISTRO-rosidl-adapter
 remove-apt-package ros-$ROS_DISTRO-rosidl-generator-c
 remove-apt-package ros-$ROS_DISTRO-rosidl-generator-cpp
-remove-apt-package ros-$ROS_DISTRO-rosidl-generator-py
 remove-apt-package ros-$ROS_DISTRO-ament-cmake-gmock
 remove-apt-package ros-$ROS_DISTRO-python-cmake-module
 remove-apt-package python3-pytest


### PR DESCRIPTION
stop removing the python3 used at runtime for interface validation

These packages are used by the from rclpy.type_support import
 check_is_valid_msg_type

at the creation of publishers